### PR TITLE
Log request body. Made small refactoring when logging Service Fabric properties

### DIFF
--- a/src/ServiceFabric.Logging/Extensions/HttpRequestExtensions.cs
+++ b/src/ServiceFabric.Logging/Extensions/HttpRequestExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+
+namespace ServiceFabric.Logging.Extensions
+{
+    public static class HttpRequestExtensions
+    {
+        public static string ReadRequestBodyAsString(this HttpRequest request)
+        {
+            string requestBodyAsText = null;
+
+            if (!HttpMethods.IsGet(request.Method)
+                && !HttpMethods.IsHead(request.Method)
+                && !HttpMethods.IsDelete(request.Method)
+                && !HttpMethods.IsTrace(request.Method)
+                && request.ContentLength > 0)
+            {
+                using (var reader = new StreamReader(request.Body))
+                {
+                    requestBodyAsText = reader.ReadToEnd();
+                }
+            }
+            return requestBodyAsText;
+        }
+
+        public static string ReadHeadersAsString(this HttpRequest request)
+        {
+            var headers = new StringBuilder();
+            foreach (string key in request.Headers.Keys)
+            {
+                string value = request.Headers[key];
+                if (!string.IsNullOrEmpty(value))
+                {
+                    headers.AppendLine($"{key}={value}");
+                }
+            }
+            return headers.ToString();
+        }
+    }
+}

--- a/src/ServiceFabric.Logging/FabricEnvironmentVariable.cs
+++ b/src/ServiceFabric.Logging/FabricEnvironmentVariable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace ServiceFabric.Logging
+{
+    public static class FabricEnvironmentVariable
+    {
+        public static string ApplicationName => Environment.GetEnvironmentVariable("Fabric_ApplicationName");
+        public static string ServicePackageName => Environment.GetEnvironmentVariable("Fabric_ServicePackageName");
+        public static string ServicePackageInstanceId => Environment.GetEnvironmentVariable("Fabric_ServicePackageInstanceId");
+        public static string ServicePackageActivationId => Environment.GetEnvironmentVariable("Fabric_ServicePackageActivationId");
+        public static string NodeName => Environment.GetEnvironmentVariable("Fabric_NodeName");
+    }
+}

--- a/src/ServiceFabric.Logging/PropertyMap/ApiRequestProperties.cs
+++ b/src/ServiceFabric.Logging/PropertyMap/ApiRequestProperties.cs
@@ -11,6 +11,7 @@
         public const string Response = "Response";
         public const string Success = "Success";
         public const string StartTime = "StartTime";
-        public const string Headers = "Headers";
+        public const string Headers = "RequestHeaders";
+        public const string Body = "RequestBody";
     }
 }

--- a/src/ServiceFabric.Logging/PropertyMap/ServiceContextProperties.cs
+++ b/src/ServiceFabric.Logging/PropertyMap/ServiceContextProperties.cs
@@ -1,0 +1,15 @@
+﻿namespace ServiceFabric.Logging.PropertyMap
+{
+    public static class ServiceContextProperties
+    {
+        public const string ServiceName = "ServiceFabric.ServiceName";
+        public const string ServiceTypeName = "ServiceFabric.ServiceTypeName";
+        public const string PartitionId = "ServiceFabric.PartitionId";
+        public const string ApplicationName = "ServiceFabric.ApplicationName";
+        public const string ApplicationTypeName = "ServiceFabric.ApplicationTypeName";
+        public const string NodeName = "ServiceFabric.NodeName";
+        public const string InstanceId = "ServiceFabric.InstanceId";
+        public const string ReplicaId = "ServiceFabric.ReplicaId";
+        public const string ServicePackageVersion = "ServiceFabric.ServicePackageVersion";
+    }
+}

--- a/src/WebApi/Controllers/ValuesController.cs
+++ b/src/WebApi/Controllers/ValuesController.cs
@@ -37,5 +37,11 @@ namespace WebApi.Controllers
 
             return sum;
         }
+
+        [HttpPost]
+        public IActionResult Post([FromBody] string data)
+        {
+            return new StatusCodeResult(201);
+        }
     }
 }


### PR DESCRIPTION
Hello,
I recently investigated the [ApplicationInsights-ServiceFabric](https://github.com/Microsoft/ApplicationInsights-ServiceFabric) package from Microsoft it is definetly that your solution is more flexible and collect more telemetry 🥇 👍 

I made a few improvements when logging `ServiceContext` properties that I saw in that repo. Also, in my case I need to log body of **POST/PATCH** request and I think it would be nice feature. I tried to implement it but need some your advices what do you think about it and what it can be improved _(I don't like that solution but is is only prototype_).
So, please review if you have time. 

Thank you inadvance.